### PR TITLE
feat: add persistent like button with login prompt

### DIFF
--- a/src/components/PostCard.jsx
+++ b/src/components/PostCard.jsx
@@ -1,6 +1,7 @@
-import HeartIcon from '/src/assets/heart-icon.svg';
-import CommentIcon from '/src/assets/comment-icon.svg';
-import ShareIcon from '/src/assets/share-icon.svg';
+import React from "react";
+import CommentIcon from "/src/assets/comment-icon.svg";
+import ShareIcon from "/src/assets/share-icon.svg";
+import LikesCount from "/src/likes-count/likes-count";
 
 const PostCard = ({ post }) => {
     const {
@@ -8,50 +9,67 @@ const PostCard = ({ post }) => {
         createdAt,
         content,
         imageUrl,
-        likes,
         comments,
         shares,
-        userAvatarUrl
+        userAvatarUrl,
+        id,
     } = post;
 
-    const date = createdAt?.toDate().toLocaleDateString("nl-NL", {
-        day: 'numeric', month: 'short'
-    });
+    const date = createdAt
+        ?.toDate()
+        .toLocaleDateString("nl-NL", { day: "numeric", month: "short" });
 
     return (
         <>
             <div className="post-card">
                 <div className="side-container">
-                    <img src={userAvatarUrl || "/assets/profile-photo.png"} alt="Profile" />
+                    <img
+                        src={userAvatarUrl || "/assets/profile-photo.png"}
+                        alt="Profile"
+                    />
                 </div>
 
                 <div className="details-container">
                     <div className="user-info-container">
                         <h4>{username || "Unknown"}</h4>
-                        <p className={"post-date"}>{date || "Unknown date"}</p>
+                        <p className="post-date">{date || "Unknown date"}</p>
                     </div>
 
                     <p>{content}</p>
 
                     {imageUrl && (
-                        <img src={imageUrl} alt="Post" style={{ maxWidth: "100%", marginTop: "10px", borderRadius: "10px" }} />
+                        <img
+                            src={imageUrl}
+                            alt="Post"
+                            style={{
+                                maxWidth: "100%",
+                                marginTop: "10px",
+                                borderRadius: "10px",
+                            }}
+                        />
                     )}
 
                     <div className="actions-container">
+                        {/* Like button */}
                         <div className="actions-box">
-                            <img src={HeartIcon} alt="Heart" />                            <p>{likes}</p>
+                            <LikesCount postId={id} />
                         </div>
+
+                        {/* Comments */}
                         <div className="actions-box">
-                            <img src={CommentIcon} alt="" />
+                            <img src={CommentIcon} alt="Comment" />
                             <p>{comments}</p>
                         </div>
+
+                        {/* Shares */}
                         <div className="actions-box">
-                            <img src={ShareIcon} alt="" />
+                            <img src={ShareIcon} alt="Share" />
                             <p>{shares}</p>
                         </div>
                     </div>
                 </div>
             </div>
+
             <hr className="divider" />
         </>
     );

--- a/src/components/auth/logout.css
+++ b/src/components/auth/logout.css
@@ -1,0 +1,12 @@
+.logout-btn {
+    background: transparent;
+    border: 1px solid var(--secondary-color);
+    color: var(--secondary-color);
+    padding: 0.25rem 0.75rem;
+    border-radius: var(--radius-small);
+    cursor: pointer;
+}
+.logout-btn:hover {
+    background: var(--secondary-color);
+    color: var(--primary-color);
+}

--- a/src/components/auth/logout.jsx
+++ b/src/components/auth/logout.jsx
@@ -1,0 +1,26 @@
+// src/components/LogoutButton.jsx
+
+import React from "react";
+import { signOut } from "firebase/auth";
+import { auth } from "../firebase";
+import { useNavigate } from "react-router-dom";
+
+export default function LogoutButton() {
+    const navigate = useNavigate();
+
+    const handleLogout = async () => {
+        try {
+            await signOut(auth);
+            // after sign-out, send ’em to the login screen
+            navigate("/login");
+        } catch (error) {
+            console.error("Logout failed:", error);
+        }
+    };
+
+    return (
+        <button onClick={handleLogout} className="logout-btn">
+            Logout
+        </button>
+    );
+}

--- a/src/likes-count/like-count.css
+++ b/src/likes-count/like-count.css
@@ -1,0 +1,28 @@
+/* src/likes-count/like-count.css */
+
+.heart-btn {
+    cursor: pointer;
+    background: transparent !important;
+    border: none !important;
+    padding: 0 !important;
+    margin: 0 !important;
+    display: inline-flex;
+    align-items: center;
+    gap: 4px;
+}
+
+.heart-btn img {
+    /* default (unliked) icon style */
+    filter: grayscale(1) brightness(0.8);
+}
+
+.heart-btn.liked img {
+    /* red tint when liked */
+    filter: invert(44%) sepia(84%) saturate(4333%) hue-rotate(329deg)
+    brightness(96%) contrast(90%);
+}
+
+.heart-btn:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+}

--- a/src/likes-count/likes-count.jsx
+++ b/src/likes-count/likes-count.jsx
@@ -1,0 +1,83 @@
+// src/likes-count/likes-count.jsx
+
+import React, { useState, useEffect } from "react";
+import HeartIcon from "/src/assets/heart-icon.svg";
+import { auth, db } from "../firebase";
+import "./like-count.css";
+import {
+    doc,
+    getDoc,
+    updateDoc,
+    increment,
+    arrayUnion,
+    arrayRemove,
+} from "firebase/firestore";
+
+export default function LikesCount({ postId }) {
+    const [isLoggedIn, setIsLoggedIn] = useState(false);
+    const [likeCount, setLikeCount] = useState(0);
+    const [hasLiked, setHasLiked] = useState(false);
+    const [busy, setBusy] = useState(false);
+
+    // watch auth state
+    useEffect(() => {
+        const unsubscribe = auth.onAuthStateChanged(user => {
+            setIsLoggedIn(!!user);
+        });
+        return () => unsubscribe();
+    }, []);
+
+    // fetch initial like data
+    useEffect(() => {
+        const ref = doc(db, "posts", postId);
+        getDoc(ref).then(snap => {
+            const data = snap.data() || {};
+            setLikeCount(data.likes || 0);
+            setHasLiked(data.likedBy?.includes(auth.currentUser?.uid));
+        });
+    }, [postId]);
+
+    const handleLike = async () => {
+        // 1. require login
+        if (!isLoggedIn) {
+            alert("You need to log in first");
+            window.location.href = "/login";
+            return;
+        }
+
+        setBusy(true);
+        const ref = doc(db, "posts", postId);
+
+        if (hasLiked) {
+            // unlike
+            await updateDoc(ref, {
+                likes: increment(-1),
+                likedBy: arrayRemove(auth.currentUser.uid),
+            });
+            setHasLiked(false);
+            setLikeCount(prev => prev - 1);
+        } else {
+            // like
+            await updateDoc(ref, {
+                likes: increment(1),
+                likedBy: arrayUnion(auth.currentUser.uid),
+            });
+            setHasLiked(true);
+            setLikeCount(prev => prev + 1);
+        }
+
+        setBusy(false);
+    };
+
+    return (
+        <button
+            onClick={handleLike}
+            disabled={busy}
+            className={`heart-btn ${hasLiked ? "liked" : ""}`}
+            style={{ display: "inline-flex", alignItems: "center", gap: "4px", background: "transparent", border: "none", padding: 0 }}
+        >
+            <img src={HeartIcon} alt="Like" />
+            <span style={{ color: "#fff" }}>{likeCount}</span>
+        </button>
+    );
+}

--- a/src/styling/side-header.css
+++ b/src/styling/side-header.css
@@ -48,6 +48,7 @@
 }
 
 
+
 /*.Posts-container{*/
 /*    display: flex;*/
 /*    justify-content: center;*/

--- a/src/styling/styling.css
+++ b/src/styling/styling.css
@@ -144,3 +144,40 @@ main {
         justify-content: center;
     }
 }
+/* make the like button completely transparent */
+.heart-btn {
+    background-color: transparent !important;
+    border: none !important;
+    padding: 0 !important;
+    margin: 0 !important;
+}
+
+/* ensure the icon itself has no background */
+.heart-btn img {
+    background-color: transparent !important;
+}
+
+/* ensure the number has no background */
+.heart-btn p {
+    background-color: transparent !important;
+    color: white;
+}
+.heart-btn {
+    display: flex;
+    align-items: center;
+    gap: 4px;          /* space between icon and number */
+    background: transparent;
+    border: none;
+    padding: 0;
+    margin: 0;
+}
+/* normal (unliked) heart is light/grey */
+.heart-btn img {
+    filter: grayscale(1) brightness(0.8);
+}
+
+/* once liked, swap to red tint */
+.heart-btn.liked img {
+    filter: invert(44%) sepia(84%) saturate(4333%) hue-rotate(329deg)
+    brightness(96%) contrast(90%);
+}


### PR DESCRIPTION
    - Created LikesCount component to fetch and display Firestore like counts
    - Enforced auth check: show browser alert “You need to log in first” if not signed in
    - Wired up updateDoc calls to increment/decrement likes and manage likedBy array
    - Styled heart button with inline-flex layout, transparent background, red tint when liked
    - Replaced inline heart in PostCard with <LikesCount postId={id} />
    - Cleaned up CSS in like-count.css for .heart-btn and removed white background
    - Tested guest and authenticated flows to ensure persistence across refresh